### PR TITLE
Update deprovision tasks to use ansible kubernetes modules

### DIFF
--- a/roles/deprovision-fh-sync-server-apb/defaults/main.yml
+++ b/roles/deprovision-fh-sync-server-apb/defaults/main.yml
@@ -1,0 +1,1 @@
+sync_server_route_name: fh-sync-server

--- a/roles/deprovision-fh-sync-server-apb/tasks/main.yml
+++ b/roles/deprovision-fh-sync-server-apb/tasks/main.yml
@@ -1,14 +1,42 @@
-- name: delete fh-sync-server resource
-  command: oc delete {{ item }} fh-sync-server -n {{ namespace }}
+- name: delete route
+  openshift_v1_route:
+    name: '{{ sync_server_route_name }}'
+    namespace: '{{ namespace }}'
+    state: absent
+
+- name: delete services
+  k8s_v1_service:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
   with_items:
-    - service
-    - route
-- name: delete sync-redis resoures
-  command: oc delete {{ item }} redis -n {{ namespace }}
+  - fh-sync-server
+  - mongodb
+  - redis
+
+- name: delete deployments
+  k8s_apps_v1beta1_deployment:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
   with_items:
-    - service
-- name: delete sync-mongo resoures
-  command: oc delete {{ item }} mongodb -n {{ namespace }}
+  - fh-sync-server
+  - mongodb
+  - redis
+
+- name: delete secrets
+  k8s_v1_secret:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
   with_items:
-    - service
-    - secret
+  - fh-sync-server
+  - mongodb
+
+- name: delete persistent volume claims
+  k8s_v1_persistent_volume_claim:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
+  with_items:
+  - mongodb

--- a/roles/provision-fh-sync-server-apb/templates/deploy.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/deploy.yml.j2
@@ -56,6 +56,7 @@ objects:
     labels:
       app: fh-sync-server
       template: fh-sync-server
+      mobile: enabled
     name: mongodb
   spec:
     ports:
@@ -75,6 +76,7 @@ objects:
     labels:
       app: fh-sync-server
       template: fh-sync-server
+      mobile: enabled
   spec:
     ports:
     - port: 6379
@@ -147,6 +149,7 @@ objects:
     labels:
       app: fh-sync-server
       template: fh-sync-server
+      mobile: enabled
     name: mongodb
   spec:
     replicas: 1
@@ -317,6 +320,7 @@ objects:
     labels:
       app: fh-sync-server
       template: fh-sync-server
+      mobile: enabled
     name: mongodb
   type: Opaque
 
@@ -327,6 +331,7 @@ objects:
     labels:
       app: fh-sync-server
       template: fh-sync-server
+      mobile: enabled
   spec:
     accessModes:
     - ReadWriteOnce

--- a/roles/provision-fh-sync-server-apb/templates/deploy.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/deploy.yml.j2
@@ -319,6 +319,7 @@ objects:
       template: fh-sync-server
     name: mongodb
   type: Opaque
+
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:


### PR DESCRIPTION
Currently our deprovision task uses the shell module to run the oc
tool to delete resources. This is messy and will fail if for some
reason the resource never existed in the first place.

This updates the deprovision task to use the ansible kubernetes
modules that are provided to the ansible task.

Also this change removes resources that are not currently deleted
in the current deprovision task.