### PR TITLE
[AEROGEAR-2373] Add labels to secret and configmap

### DIFF
--- a/roles/provision-fh-sync-server-apb/tasks/main.yml
+++ b/roles/provision-fh-sync-server-apb/tasks/main.yml
@@ -1,16 +1,3 @@
-- name: "Get the name of the service instance"
-  shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
-  when: _apb_service_instance_id is defined
-  register: service_instance_name
-
-- name: "Label the service instance with the service name"
-  shell: oc label serviceinstance '{{ service_instance_name.stdout }}' serviceName=fh-sync-server --namespace={{ namespace }}
-  when: _apb_service_instance_id is defined
-
-- name: "Label the service instance with mobile enabled"
-  shell: oc label serviceinstance '{{ service_instance_name.stdout }}' mobile=enabled --namespace={{ namespace }}
-  when: _apb_service_instance_id is defined  
-
 - name: "Create fh-sync-server deploy yaml file"
   template:
     src: deploy.yml.j2
@@ -23,24 +10,32 @@
   shell: "oc get routes fh-sync-server -n {{ namespace }} | grep -v NAME | awk '{print $2}'"
   register: fhsync_route
 
-- k8s_v1_secret:
-    name: fh-sync-server
-    namespace: '{{ namespace }}'
-    labels:
-      mobile: enabled
-      serviceName: fh-sync-server
-    string_data:
-      name: "{{ fhsync_secret_name }}"
-      type: "{{ fhsync_secret_name }}"
-      uri: https://{{ fhsync_route.stdout }}
+- name: "Create fh-sync-server secret template"
+  template:
+    src: secret.yml.j2
+    dest: /tmp/secret.yaml
+  when: _apb_service_instance_id is defined
 
-- k8s_v1_config_map:
-    name: fh-sync-server
-    namespace: '{{ namespace }}'
-    labels:
-      mobile: enabled
-      serviceName: fh-sync-server
-    data:
-      name: "{{ fhsync_secret_name }}"
-      type: "{{ fhsync_secret_name }}"
-      uri: https://{{ fhsync_route.stdout }}
+- name: "Create fh-sync-server secret template for testing"
+  template:
+    src: secret_test.yml.j2
+    dest: /tmp/secret.yaml
+  when: _apb_service_instance_id is not defined
+
+- name: "Create fh-sync-server secret"
+  shell: "oc create -f /tmp/secret.yaml -n {{ namespace }}"  
+
+- name: "Create fh-sync-server configmap template"
+  template:
+    src: configmap.yml.j2
+    dest: /tmp/configmap.yaml
+  when: _apb_service_instance_id is defined
+
+- name: "Create fh-sync-server configmap template for testing"
+  template:
+    src: configmap_test.yml.j2
+    dest: /tmp/configmap.yaml
+  when: _apb_service_instance_id is not defined
+
+- name: Create fh-sync-server config map
+  shell: oc create -f /tmp/configmap.yaml -n {{ namespace }}

--- a/roles/provision-fh-sync-server-apb/templates/configmap.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/configmap.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fh-sync-server
+  namespace: {{ namespace }}
+  labels:
+    mobile: enabled
+    serviceName: fh-sync-server
+    serviceInstanceID: '{{ _apb_service_instance_id }}'
+data:
+  type: {{ fhsync_secret_name }}
+  name: {{ fhsync_secret_name }}
+  uri: https://{{ fhsync_route.stdout }}

--- a/roles/provision-fh-sync-server-apb/templates/configmap_test.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/configmap_test.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fh-sync-server
+  namespace: {{ namespace }}
+  labels:
+    mobile: enabled
+    serviceName: fh-sync-server
+data:
+  type: {{ fhsync_secret_name }}
+  name: {{ fhsync_secret_name }}
+  uri: https://{{ fhsync_route.stdout }}

--- a/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/secret.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ fhsync_secret_name }}
+  namespace: {{ namespace }}
+  labels:
+    mobile: enabled
+    serviceName: fh-sync-server
+    serviceInstanceID: '{{ _apb_service_instance_id }}'
+stringData:
+  name: {{ fhsync_secret_name }}
+  type: {{ fhsync_secret_name }}
+  uri: https://{{ fhsync_route.stdout }}

--- a/roles/provision-fh-sync-server-apb/templates/secret_test.yml.j2
+++ b/roles/provision-fh-sync-server-apb/templates/secret_test.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ fhsync_secret_name }}
+  namespace: {{ namespace }}
+  labels:
+    mobile: enabled
+    serviceName: fh-sync-server
+stringData:
+  name: {{ fhsync_secret_name }}
+  type: {{ fhsync_secret_name }}
+  uri: https://{{ fhsync_route.stdout }}


### PR DESCRIPTION
**Description**
* Remove the service instance labelling task 
* Move secret and configmap to external templates
* Add the service instance id and service name labels to both the secret and the configmap

**Verification steps**
1. Provision fh-sync-server from this branch
2. Verify the service instance is no longer labelled with `serviceName` and `mobile:enabled`
3. Verify that the configmap is correctly labelled with `mobile:enabled`, `serviceName` and `serviceInstanceID`
4. Verify that the secret is correctly labelled with `mobile:enabled`, `serviceName` and `serviceInstanceID`
5. Verify that the `serviceInstanceID` label matches the `spec.externalID` of the service instance